### PR TITLE
fix: resolve extended text box save issue when question title has a c…

### DIFF
--- a/classes/components/forms/CustomQuestions.php
+++ b/classes/components/forms/CustomQuestions.php
@@ -43,7 +43,7 @@ class CustomQuestions extends FormComponent
         $customQuestionResponse = Repo::customQuestionResponse()
             ->getByCustomQuestionId($customQuestion->getId(), $submissionId);
 
-        $fieldName = $this->toKebabCase($customQuestion->getLocalizedTitle()) . '-' . $customQuestion->getId();
+        $fieldName = 'customQuestion-' . $customQuestion->getId();
         $fieldComponents = [
             CustomQuestion::CUSTOM_QUESTION_TYPE_SMALL_TEXT_FIELD => new FieldText(
                 $fieldName,


### PR DESCRIPTION
The form's fieldName generation was based on the custom question's title. 
If the title contained a comma, it would generate an invalid HTML ID/CSS selector that caused the TinyMCE initialization to silently fail in the frontend, preventing  the value from being saved.

Updated fieldName to use a static and safe prefix ('customQuestion-') alongside the custom question ID.